### PR TITLE
Release for 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/44
 - composer を追加してみる by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/46
 
+## [1.0.7](https://github.com/T-Toshiya/github-actions-test/compare/21220621.2.3...1.0.7) - 2022-12-17
+- readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/42
+- readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/44
+- composer を追加してみる by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/46
+
 ## [21220621.2.3](https://github.com/T-Toshiya/github-actions-test/compare/21220621.2.2...21220621.2.3) - 2022-12-17
 - readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/40
 


### PR DESCRIPTION
This pull request is for the next release as 1.0.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 1.0.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-21220621.2.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at 1.0.7 -->

## What's Changed
* readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/42
* readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/44
* composer を追加してみる by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/46


**Full Changelog**: https://github.com/T-Toshiya/github-actions-test/compare/21220621.2.3...1.0.7