### PR TITLE
Release for v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.0.7](https://github.com/T-Toshiya/github-actions-test/compare/21220621.2.3...v1.0.7) - 2022-12-17
+- readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/42
+- readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/44
+- composer を追加してみる by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/46
+- readme を修正 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/48
+- 設定ファイルを修正 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/50
+
 ## [1.0.7](https://github.com/T-Toshiya/github-actions-test/compare/21220621.2.3...1.0.7) - 2022-12-17
 - readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/42
 - readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/44


### PR DESCRIPTION
This pull request is for the next release as v1.0.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.0.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v21220621.2.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/42
* readmeを追記 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/44
* composer を追加してみる by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/46
* readme を修正 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/48
* 設定ファイルを修正 by @T-Toshiya in https://github.com/T-Toshiya/github-actions-test/pull/50


**Full Changelog**: https://github.com/T-Toshiya/github-actions-test/compare/21220621.2.3...v1.0.7